### PR TITLE
Fix feature map indexing in Keras loss

### DIFF
--- a/utils/util_keras.py
+++ b/utils/util_keras.py
@@ -556,7 +556,10 @@ class ComputeLoss(Layer):
         print(f"[utils/util.py::ComputeLoss.__call__] After permute - pred_scores shape: {pred_scores.shape}")
         
         
-        hw = tf.cast(tf.shape(x[0])[1:3], dtype=pred_scores.dtype)  # (h, w)
+        # The feature maps have been converted to NCHW format above so the
+        # spatial dimensions are at indices 2 and 3. Use these to compute the
+        # feature map size (height, width) before reversing to (width, height).
+        hw = tf.cast(tf.shape(x[0])[2:4], dtype=pred_scores.dtype)  # (h, w)
         size = tf.reverse(hw, axis=[0]) * self.stride[0]  # (w, h) * stride
         anchor_points, stride_tensor = make_anchors_tf(x, self.stride, 0.5)
         # Use cast_like for critical operations


### PR DESCRIPTION
## Summary
- fix feature map size calculation in `ComputeLoss` for Keras

## Testing
- `python -m py_compile utils/util_keras.py`

------
https://chatgpt.com/codex/tasks/task_e_6854857a5db0832d96b3c2124a4eccd2