### PR TITLE
Add Keras size tensor debug

### DIFF
--- a/utils/util_keras.py
+++ b/utils/util_keras.py
@@ -560,8 +560,9 @@ class ComputeLoss(Layer):
         # spatial dimensions are at indices 2 and 3. Use these to compute the
         # feature map size (height, width) before reversing to (width, height).
         hw = tf.cast(tf.shape(x[0])[2:4], dtype=pred_scores.dtype)  # (h, w)
-        size = tf.reverse(hw, axis=[0]) * self.stride[0]  # (w, h) * stride
+        size = hw * self.stride[0]  # (h, w) * stride
         print(f"[utils/util.py::ComputeLoss.__call__] Size tensor: {size}")
+        print(f"[utils/util.py::ComputeLoss.__call__] Size tensor: {size.numpy()}")
         
         anchor_points, stride_tensor = make_anchors_tf(x, self.stride, 0.5)
         # Use cast_like for critical operations


### PR DESCRIPTION
## Summary
- print size tensor using `.numpy()` inside `ComputeLoss.call`
- orientation now matches PyTorch

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
import tensorflow as tf
from nets.tinysimov35_keras import yolo_v8_s
from utils.util_keras import ComputeLoss
params={'cls':0.5,'box':7.5,'dfl':1.5,'names':{0:'cell'}}
model=yolo_v8_s(num_classes=1,img_size=(128,256),dtype=tf.float32)
criterion=ComputeLoss(model,params,dtype=tf.float32)
x=tf.zeros([1,128,256,3],dtype=tf.float32)
outputs=model(x,training=True)
targets=tf.zeros([0,6],dtype=tf.float32)
loss=criterion(outputs,targets)
print('Loss:',loss.numpy())
EOF

------
https://chatgpt.com/codex/tasks/task_e_68548ffa15ac832d8019dd6173e7b5d5