### PR TITLE
Add batch index to Keras targets

### DIFF
--- a/utils/dataset_keras.py
+++ b/utils/dataset_keras.py
@@ -78,6 +78,8 @@ class Dataset:
                     label[:, 1] = 1 - label[:, 1]
 
         target = np.zeros((nl, 6))
+        # Column 0 is reserved for the batch index which is filled in the
+        # training data generator. The remaining columns hold label data.
         if nl:
             target[:, 1:] = label
         


### PR DESCRIPTION
## Summary
- set image index in `data_generator` just like PyTorch
- document that first column of targets stores the batch index

## Testing
- `python -m py_compile main_keras.py utils/dataset_keras.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a72c9cac832d9ff970613b2342d7